### PR TITLE
fix Base64::decode method documentation

### DIFF
--- a/src/Base64.php
+++ b/src/Base64.php
@@ -84,7 +84,7 @@ abstract class Base64 implements EncoderInterface
      *
      * @param string $src
      * @param bool $strictPadding
-     * @return string|bool
+     * @return string
      * @throws \RangeException
      */
     public static function decode(string $src, bool $strictPadding = false): string


### PR DESCRIPTION
Fix for issue #6, the method can only return a string, no longer
a bool