### PR TITLE
Duplicated code

### DIFF
--- a/src/Binary.php
+++ b/src/Binary.php
@@ -69,15 +69,11 @@ abstract class Binary
         int $start = 0,
         $length = null
     ): string {
-        if (\function_exists('mb_substr')) {
-            // $length calculation above might result in a 0-length string
-            if ($length === 0) {
-                return '';
-            }
-            return \mb_substr($str, $start, $length, '8bit');
-        }
         if ($length === 0) {
             return '';
+        }
+        if (\function_exists('mb_substr')) {
+            return \mb_substr($str, $start, $length, '8bit');
         }
         // Unlike mb_substr(), substr() doesn't accept NULL for length
         if ($length !== null) {


### PR DESCRIPTION
The following code:
```
if ($length === 0) {
     return '';
}
```
Appears twice without need. [Before](https://github.com/paragonie/constant_time_encoding/commit/aa342bff0f39b72da79b62b72d95a9bb86aa80b9) this condition is used in the "PHP 5.3 Hack", but now this might to be consider just duplicated.