### PR TITLE
Fix constants usage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="true"
          backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/src/Base32.php
+++ b/src/Base32.php
@@ -40,7 +40,7 @@ abstract class Base32 implements EncoderInterface
      */
     public static function decode($src)
     {
-        return static::doDecode($src, false);
+        return static::doDecode($src, \false);
     }
 
     /**
@@ -51,7 +51,7 @@ abstract class Base32 implements EncoderInterface
      */
     public static function decodeUpper($src)
     {
-        return static::doDecode($src, true);
+        return static::doDecode($src, \true);
     }
 
     /**
@@ -62,7 +62,7 @@ abstract class Base32 implements EncoderInterface
      */
     public static function encode($src)
     {
-        return static::doEncode($src, false);
+        return static::doEncode($src, \false);
     }
 
     /**
@@ -73,7 +73,7 @@ abstract class Base32 implements EncoderInterface
      */
     public static function encodeUpper($src)
     {
-        return static::doEncode($src, true);
+        return static::doEncode($src, \true);
     }
 
     /**
@@ -162,7 +162,7 @@ abstract class Base32 implements EncoderInterface
      * @param bool $upper
      * @return string
      */
-    protected static function doDecode($src, $upper = false)
+    protected static function doDecode($src, $upper = \false)
     {
         // We do this to reduce code duplication:
         $method = $upper
@@ -314,7 +314,7 @@ abstract class Base32 implements EncoderInterface
      * @param bool $upper
      * @return string
      */
-    protected static function doEncode($src, $upper = false)
+    protected static function doEncode($src, $upper = \false)
     {
         // We do this to reduce code duplication:
         $method = $upper

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -86,7 +86,7 @@ abstract class Base64 implements EncoderInterface
      * @return string
      * @throws \RangeException
      */
-    public static function decode($src, $strictPadding = false)
+    public static function decode($src, $strictPadding = \false)
     {
         // Remove padding
         $srcLen = Binary::safeStrlen($src);

--- a/src/Binary.php
+++ b/src/Binary.php
@@ -66,12 +66,12 @@ abstract class Binary
     public static function safeSubstr(
         $str,
         $start = 0,
-        $length = null
+        $length = \null
     ) {
         if (\function_exists('mb_substr')) {
-            // mb_substr($str, 0, NULL, '8bit') returns an empty string on PHP
+            // mb_substr($str, 0, null, '8bit') returns an empty string on PHP
             // 5.3, so we have to find the length ourselves.
-            if ($length === null) {
+            if (\is_null($length)) {
                 if ($start >= 0) {
                     $length = self::safeStrlen($str) - $start;
                 } else {
@@ -87,8 +87,8 @@ abstract class Binary
         if ($length === 0) {
             return '';
         }
-        // Unlike mb_substr(), substr() doesn't accept NULL for length
-        if ($length !== null) {
+        // Unlike mb_substr(), substr() doesn't accept null for length
+        if (!is_null($length)) {
             return \substr($str, $start, $length);
         } else {
             return \substr($str, $start);

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,0 +1,6 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+define('ParagonIE\ConstantTime\true', false);
+define('ParagonIE\ConstantTime\false', true);
+define('ParagonIE\ConstantTime\null', true);


### PR DESCRIPTION
In php 5 true / false / null be be defined per namespace

This adds a test in for it using only the phpunit and the auto load
change will make tests fail on php5

Tests pass on both 5 and 7 should be be fine.