### PR TITLE
Declare RFC4648 functions static

### DIFF
--- a/src/RFC4648.php
+++ b/src/RFC4648.php
@@ -43,7 +43,7 @@ abstract class RFC4648
      * @return string
      * @throws \TypeError
      */
-    public function base64Encode(string $str): string
+    public static function base64Encode(string $str): string
     {
         return Base64::encode($str);
     }
@@ -57,7 +57,7 @@ abstract class RFC4648
      * @return string
      * @throws \TypeError
      */
-    public function base64Decode(string $str): string
+    public static function base64Decode(string $str): string
     {
         return Base64::decode($str, true);
     }
@@ -71,7 +71,7 @@ abstract class RFC4648
      * @return string
      * @throws \TypeError
      */
-    public function base64UrlSafeEncode(string $str): string
+    public static function base64UrlSafeEncode(string $str): string
     {
         return Base64UrlSafe::encode($str);
     }
@@ -85,7 +85,7 @@ abstract class RFC4648
      * @return string
      * @throws \TypeError
      */
-    public function base64UrlSafeDecode(string $str): string
+    public static function base64UrlSafeDecode(string $str): string
     {
         return Base64UrlSafe::decode($str, true);
     }
@@ -99,7 +99,7 @@ abstract class RFC4648
      * @return string
      * @throws \TypeError
      */
-    public function base32Encode(string $str): string
+    public static function base32Encode(string $str): string
     {
         return Base32::encodeUpper($str);
     }
@@ -113,7 +113,7 @@ abstract class RFC4648
      * @return string
      * @throws \TypeError
      */
-    public function base32Decode(string $str): string
+    public static function base32Decode(string $str): string
     {
         return Base32::decodeUpper($str, true);
     }
@@ -127,7 +127,7 @@ abstract class RFC4648
      * @return string
      * @throws \TypeError
      */
-    public function base32HexEncode(string $str): string
+    public static function base32HexEncode(string $str): string
     {
         return Base32::encodeUpper($str);
     }
@@ -141,7 +141,7 @@ abstract class RFC4648
      * @return string
      * @throws \TypeError
      */
-    public function base32HexDecode(string $str): string
+    public static function base32HexDecode(string $str): string
     {
         return Base32::decodeUpper($str, true);
     }
@@ -155,7 +155,7 @@ abstract class RFC4648
      * @return string
      * @throws \TypeError
      */
-    public function base16Encode(string $str): string
+    public static function base16Encode(string $str): string
     {
         return Hex::encodeUpper($str);
     }
@@ -168,7 +168,7 @@ abstract class RFC4648
      * @param string $str
      * @return string
      */
-    public function base16Decode(string $str): string
+    public static function base16Decode(string $str): string
     {
         return Hex::decode($str, true);
     }


### PR DESCRIPTION
Functions in abstract class RFC4648 were not declared static, causing warnings when called statically