### PR TITLE
Fix exception message

### DIFF
--- a/src/Hex.php
+++ b/src/Hex.php
@@ -142,7 +142,7 @@ abstract class Hex implements EncoderInterface
 
             if (($c_num0 | $c_alpha0) === 0) {
                 throw new \RangeException(
-                    'hexEncode() only expects hexadecimal characters'
+                    'Expected hexadecimal character'
                 );
             }
             /** @var int $c_val */


### PR DESCRIPTION
The method where this is thrown in is `decode()`, which is confusing.

I think the new message is not very good either, but I tried to align it with this one for now: https://github.com/paragonie/constant_time_encoding/blob/47a1cedd2e4d52688eb8c96469c05ebc8fd28fa2/src/Hex.php#L120

Maybe we can improve the messages in a later step...