### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,19 @@ matrix:
     - php: "7.4"
     - php: "8.0"
     - php: "nightly"
+#Added power jobs
+    - php: "7.1"
+      arch: ppc64le
+    - php: "7.2"
+      arch: ppc64le
+    - php: "7.3"
+      arch: ppc64le
+    - php: "7.4"
+      arch: ppc64le
+    - php: "8.0"
+      arch: ppc64le
+    - php: "nightly"
+      arch: ppc64le  
   allow_failures:
     - php: "nightly"
     - php: "7.4"


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra