### PR TITLE
PHP 5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,33 @@ name: CI
 on: [push]
 
 jobs:
+  ancient:
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-16.04']
+        php-versions: ['5.6']
+        phpunit-versions: ['5.7.27']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl
+          ini-values: post_max_size=256M, max_execution_time=180
+          tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+
+      - name: Install dependencies
+        run: composer self-update --1; composer install
+
+      - name: PHPUnit tests
+        uses: php-actions/phpunit@v2
+        with:
+          memory_limit: 256M
   old:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: ['ubuntu-16.04']
+        operating-system: ['ubuntu-18.04']
         php-versions: ['5.6']
         phpunit-versions: ['5.7.27']
     steps:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: ['ubuntu-16.04']
+        operating-system: ['ubuntu-18.04']
         php-versions: ['7.0']
         phpunit-versions: ['6.5.14']
     steps:

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "php": "^7|^8"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6|^7|^8|^9",
+    "phpunit/phpunit": "^5|^6|^7|^8|^9",
     "vimeo/psalm": "^1|^2|^3|^4"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "source":   "https://github.com/paragonie/constant_time_encoding"
   },
   "require": {
-    "php": "^7|^8"
+    "php": "^5|^7|^8"
   },
   "require-dev": {
     "phpunit/phpunit": "^5|^6|^7|^8|^9",

--- a/src/Base32.php
+++ b/src/Base32.php
@@ -64,9 +64,9 @@ abstract class Base32 implements EncoderInterface
      * @return string
      * @throws \TypeError
      */
-    public static function encode(string $src): string
+    public static function encode(string $binString): string
     {
-        return static::doEncode($src, false, true);
+        return static::doEncode($binString, false, true);
     }
     /**
      * Encode into Base32 (RFC 4648)

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -42,9 +42,9 @@ abstract class Base64 implements EncoderInterface
      * @return string
      * @throws \TypeError
      */
-    public static function encode(string $src): string
+    public static function encode(string $binString): string
     {
-        return static::doEncode($src, true);
+        return static::doEncode($binString, true);
     }
 
     /**

--- a/src/Binary.php
+++ b/src/Binary.php
@@ -46,7 +46,7 @@ abstract class Binary
     public static function safeStrlen(string $str): int
     {
         if (\function_exists('mb_strlen')) {
-            return (int) \mb_strlen($str, '8bit');
+            return \mb_strlen($str, '8bit');
         } else {
             return \strlen($str);
         }


### PR DESCRIPTION
In the end I just added PHP 5 support back to v2. I know it's a bit of a pain to maintain something across so many PHP versions, so take it or leave it :shrug: 

I've also updated the CI runner to Ubuntu 18.04 and fixed some lint issues along the way...