### PR TITLE
Improve performance of the hex encoder

### DIFF
--- a/src/Hex.php
+++ b/src/Hex.php
@@ -45,7 +45,7 @@ abstract class Hex implements EncoderInterface
         $len = Binary::safeStrlen($binString);
         for ($i = 0; $i < $len; ++$i) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C', Binary::safeSubstr($binString, $i, 1));
+            $chunk = \unpack('C', $binString[$i]);
             $c = $chunk[1] & 0xf;
             $b = $chunk[1] >> 4;
 
@@ -73,7 +73,7 @@ abstract class Hex implements EncoderInterface
 
         for ($i = 0; $i < $len; ++$i) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C', Binary::safeSubstr($binString, $i, 2));
+            $chunk = \unpack('C', $binString[$i]);
             $c = $chunk[1] & 0xf;
             $b = $chunk[1] >> 4;
 


### PR DESCRIPTION
Single bytes can more efficiently be accessed by directly indexing the string.

This also implicitly fixes a bug without any visible effect: `encodeUpper`
retrieved two characters from the bytestring, but only ever used the first.