### PR TITLE
Update Psalm configuration

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     useDocblockTypes="true"
-    totallyTyped="true"
+    errorLevel="1"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
> psalm.xml:4:5: ConfigIssue: Attribute "totallyTyped" is deprecated and is
> going to be removed in the next major version (see https://psalm.dev/271)

From the documentation:

> (Deprecated) Setting totallyTyped to "true" is equivalent to setting
> errorLevel to "1". Setting totallyTyped to "false" is equivalent to setting
> errorLevel to "2" and reportMixedIssues to "false"