### PR TITLE
Remove obsolete psalm suppressions

### DIFF
--- a/src/Base32.php
+++ b/src/Base32.php
@@ -222,7 +222,6 @@ abstract class Base32 implements EncoderInterface
      * @return string
      *
      * @throws TypeError
-     * @psalm-suppress RedundantCondition
      */
     protected static function doDecode(
         string $src,

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -129,7 +129,6 @@ abstract class Base64 implements EncoderInterface
      *
      * @throws RangeException
      * @throws TypeError
-     * @psalm-suppress RedundantCondition
      */
     public static function decode(string $encodedString, bool $strictPadding = false): string
     {


### PR DESCRIPTION
These were added in 9c3177f6343ef2645538b8d9b5c83d5533e9527d, but no longer
appear to do anything in Psalm 4.23.0@f1fe6ff483bf325c803df9f510d09a03fd796f88.