### PR TITLE
Make PHPUnit data providers static

### DIFF
--- a/tests/Base32Test.php
+++ b/tests/Base32Test.php
@@ -53,7 +53,7 @@ class Base32Test extends TestCase
         }
     }
 
-    public function canonProvider()
+    public static function canonProvider()
     {
         return [
             ['me', 'mf'],

--- a/tests/CanonicalTrait.php
+++ b/tests/CanonicalTrait.php
@@ -9,7 +9,7 @@ use ParagonIE\ConstantTime\Binary;
  */
 trait CanonicalTrait
 {
-    public function canonicalDataProvider(): array
+    public static function canonicalDataProvider(): array
     {
         return [
             ['a'],


### PR DESCRIPTION
This fixes a deprecation in PHPUnit 10.