### PR TITLE
Make `CanonicalTrait::getNextChar()` an abstract method instead a `@m…

### DIFF
--- a/tests/CanonicalTrait.php
+++ b/tests/CanonicalTrait.php
@@ -4,9 +4,6 @@ namespace ParagonIE\ConstantTime\Tests;
 
 use ParagonIE\ConstantTime\Binary;
 
-/**
- * @method getNextChar(string $c): string
- */
 trait CanonicalTrait
 {
     public function canonicalDataProvider(): array
@@ -20,6 +17,8 @@ trait CanonicalTrait
             ["\xff\xff\xff\xff"]
         ];
     }
+
+    abstract protected function getNextChar(string $c): string;
 
     protected function increment(string $str): string
     {


### PR DESCRIPTION
…ethod` comment

This will ensure the method actually exists on a language level.