### PR TITLE
Fix: unreachable code typo

### DIFF
--- a/src/Base64.php
+++ b/src/Base64.php
@@ -245,17 +245,11 @@ abstract class Base64 implements EncoderInterface
             return '';
         }
         if (($srcLen & 3) === 0) {
-            if ($encodedString[$srcLen - 1] === '=') {
+            // If $strLen is not zero and it is divisible by 4, then its at least 4.
+            if ($encodedString[$srcLen - 1] === '=' || $encodedString[$srcLen - 2] === '=') {
                 throw new InvalidArgumentException(
                     "decodeNoPadding() doesn't tolerate padding"
                 );
-            }
-            if (($srcLen & 3) > 1) {
-                if ($encodedString[$srcLen - 2] === '=') {
-                    throw new InvalidArgumentException(
-                        "decodeNoPadding() doesn't tolerate padding"
-                    );
-                }
             }
         }
         return static::decode(


### PR DESCRIPTION
In `Base64->decodeNoPadding()` two conditional checks of `$srcLen & 3`. But it can't be zero and greater than 1 at the same time, probably that was a typo. As far as I can understand, this is just a check for padding characters in last two places, so second condition was meant as `$strLen > 1`. But its always true: in previous code it was checked to be not zero, and then checked for `$srcLen & 3` (basically "is it divisible by 4?"), so it cant be less than 4 in this branch.

So, I've done light refactoring of this place. Since its an input validation, it should not leak any significant information in context of timing attacks.