### PR TITLE
Remove `mbstring.func_overload` compatibility layer

### DIFF
--- a/src/Base32.php
+++ b/src/Base32.php
@@ -221,7 +221,7 @@ abstract class Base32 implements EncoderInterface
         string $encodedString,
         bool $upper = false
     ): string {
-        $srcLen = Binary::safeStrlen($encodedString);
+        $srcLen = \strlen($encodedString);
         if ($srcLen === 0) {
             return '';
         }
@@ -263,7 +263,7 @@ abstract class Base32 implements EncoderInterface
             : 'decode5Bits';
 
         // Remove padding
-        $srcLen = Binary::safeStrlen($src);
+        $srcLen = \strlen($src);
         if ($srcLen === 0) {
             return '';
         }
@@ -284,7 +284,7 @@ abstract class Base32 implements EncoderInterface
             }
         } else {
             $src = \rtrim($src, '=');
-            $srcLen = Binary::safeStrlen($src);
+            $srcLen = \strlen($src);
         }
 
         $err = 0;
@@ -292,7 +292,7 @@ abstract class Base32 implements EncoderInterface
         // Main loop (no padding):
         for ($i = 0; $i + 8 <= $srcLen; $i += 8) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', Binary::safeSubstr($src, $i, 8));
+            $chunk = \unpack('C*', \substr($src, $i, 8));
             /** @var int $c0 */
             $c0 = static::$method($chunk[1]);
             /** @var int $c1 */
@@ -323,7 +323,7 @@ abstract class Base32 implements EncoderInterface
         // The last chunk, which may have padding:
         if ($i < $srcLen) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', Binary::safeSubstr($src, $i, $srcLen - $i));
+            $chunk = \unpack('C*', \substr($src, $i, $srcLen - $i));
             /** @var int $c0 */
             $c0 = static::$method($chunk[1]);
 
@@ -474,12 +474,12 @@ abstract class Base32 implements EncoderInterface
             : 'encode5Bits';
         
         $dest = '';
-        $srcLen = Binary::safeStrlen($src);
+        $srcLen = \strlen($src);
 
         // Main loop (no padding):
         for ($i = 0; $i + 5 <= $srcLen; $i += 5) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', Binary::safeSubstr($src, $i, 5));
+            $chunk = \unpack('C*', \substr($src, $i, 5));
             $b0 = $chunk[1];
             $b1 = $chunk[2];
             $b2 = $chunk[3];
@@ -498,7 +498,7 @@ abstract class Base32 implements EncoderInterface
         // The last chunk, which may have padding:
         if ($i < $srcLen) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', Binary::safeSubstr($src, $i, $srcLen - $i));
+            $chunk = \unpack('C*', \substr($src, $i, $srcLen - $i));
             $b0 = $chunk[1];
             if ($i + 3 < $srcLen) {
                 $b1 = $chunk[2];

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -115,11 +115,11 @@ abstract class Base64 implements EncoderInterface
         bool $pad = true
     ): string {
         $dest = '';
-        $srcLen = Binary::safeStrlen($src);
+        $srcLen = \strlen($src);
         // Main loop (no padding):
         for ($i = 0; $i + 3 <= $srcLen; $i += 3) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', Binary::safeSubstr($src, $i, 3));
+            $chunk = \unpack('C*', \substr($src, $i, 3));
             $b0 = $chunk[1];
             $b1 = $chunk[2];
             $b2 = $chunk[3];
@@ -133,7 +133,7 @@ abstract class Base64 implements EncoderInterface
         // The last chunk, which may have padding:
         if ($i < $srcLen) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', Binary::safeSubstr($src, $i, $srcLen - $i));
+            $chunk = \unpack('C*', \substr($src, $i, $srcLen - $i));
             $b0 = $chunk[1];
             if ($i + 1 < $srcLen) {
                 $b1 = $chunk[2];
@@ -175,7 +175,7 @@ abstract class Base64 implements EncoderInterface
         bool $strictPadding = false
     ): string {
         // Remove padding
-        $srcLen = Binary::safeStrlen($encodedString);
+        $srcLen = \strlen($encodedString);
         if ($srcLen === 0) {
             return '';
         }
@@ -215,7 +215,7 @@ abstract class Base64 implements EncoderInterface
             }
         } else {
             $encodedString = \rtrim($encodedString, '=');
-            $srcLen = Binary::safeStrlen($encodedString);
+            $srcLen = \strlen($encodedString);
         }
 
         $err = 0;
@@ -223,7 +223,7 @@ abstract class Base64 implements EncoderInterface
         // Main loop (no padding):
         for ($i = 0; $i + 4 <= $srcLen; $i += 4) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', Binary::safeSubstr($encodedString, $i, 4));
+            $chunk = \unpack('C*', \substr($encodedString, $i, 4));
             $c0 = static::decode6Bits($chunk[1]);
             $c1 = static::decode6Bits($chunk[2]);
             $c2 = static::decode6Bits($chunk[3]);
@@ -240,7 +240,7 @@ abstract class Base64 implements EncoderInterface
         // The last chunk, which may have padding:
         if ($i < $srcLen) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', Binary::safeSubstr($encodedString, $i, $srcLen - $i));
+            $chunk = \unpack('C*', \substr($encodedString, $i, $srcLen - $i));
             $c0 = static::decode6Bits($chunk[1]);
 
             if ($i + 2 < $srcLen) {
@@ -287,7 +287,7 @@ abstract class Base64 implements EncoderInterface
         #[\SensitiveParameter]
         string $encodedString
     ): string {
-        $srcLen = Binary::safeStrlen($encodedString);
+        $srcLen = \strlen($encodedString);
         if ($srcLen === 0) {
             return '';
         }

--- a/src/Binary.php
+++ b/src/Binary.php
@@ -49,13 +49,7 @@ abstract class Binary
         #[\SensitiveParameter]
         string $str
     ): int {
-        if (\function_exists('mb_strlen')) {
-            // mb_strlen in PHP 7.x can return false.
-            /** @psalm-suppress RedundantCast */
-            return (int) \mb_strlen($str, '8bit');
-        } else {
-            return \strlen($str);
-        }
+        return \strlen($str);
     }
 
     /**
@@ -79,9 +73,6 @@ abstract class Binary
     ): string {
         if ($length === 0) {
             return '';
-        }
-        if (\function_exists('mb_substr')) {
-            return \mb_substr($str, $start, $length, '8bit');
         }
         // Unlike mb_substr(), substr() doesn't accept NULL for length
         if ($length !== null) {

--- a/src/Hex.php
+++ b/src/Hex.php
@@ -56,7 +56,7 @@ abstract class Hex implements EncoderInterface
             }
         }
         $hex = '';
-        $len = Binary::safeStrlen($binString);
+        $len = \strlen($binString);
         for ($i = 0; $i < $len; ++$i) {
             /** @var array<int, int> $chunk */
             $chunk = \unpack('C', $binString[$i]);
@@ -85,7 +85,7 @@ abstract class Hex implements EncoderInterface
         string $binString
     ): string {
         $hex = '';
-        $len = Binary::safeStrlen($binString);
+        $len = \strlen($binString);
 
         for ($i = 0; $i < $len; ++$i) {
             /** @var array<int, int> $chunk */
@@ -127,7 +127,7 @@ abstract class Hex implements EncoderInterface
         $hex_pos = 0;
         $bin = '';
         $c_acc = 0;
-        $hex_len = Binary::safeStrlen($encodedString);
+        $hex_len = \strlen($encodedString);
         $state = 0;
         if (($hex_len & 1) !== 0) {
             if ($strictPadding) {

--- a/tests/Base64UrlSafeTest.php
+++ b/tests/Base64UrlSafeTest.php
@@ -7,7 +7,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Base64UrlSafe;
-use ParagonIE\ConstantTime\Binary;
 use RangeException;
 use TypeError;
 
@@ -49,7 +48,7 @@ class Base64UrlSafeTest extends TestCase
 
         $random = \random_bytes(1 << 20);
         $enc = Base64UrlSafe::encode($random);
-        $this->assertTrue(Binary::safeStrlen($enc) > 65536);
+        $this->assertTrue(\strlen($enc) > 65536);
         $this->assertSame(
             $random,
             Base64UrlSafe::decode($enc)

--- a/tests/CanonicalTrait.php
+++ b/tests/CanonicalTrait.php
@@ -2,8 +2,6 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime\Tests;
 
-use ParagonIE\ConstantTime\Binary;
-
 trait CanonicalTrait
 {
     public static function canonicalDataProvider(): array
@@ -22,8 +20,8 @@ trait CanonicalTrait
 
     protected function increment(string $str): string
     {
-        $i = Binary::safeStrlen($str) - 1;
+        $i = \strlen($str) - 1;
         $c = $this->getNextChar($str[$i]);
-        return Binary::safeSubstr($str, 0, $i) . $c;
+        return \substr($str, 0, $i) . $c;
     }
 }


### PR DESCRIPTION
The `mbstring.func_overload` misfeature no longer exists in PHP 8.x which is now the minimally supported version. Thus we can directly use `strlen()` and `substr()` and avoid the indirection through the `Binary` class, improving performance.