### PR TITLE
Re-enable CI for Pull Requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   moderate-modern:

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,6 +1,6 @@
 name: Psalm
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   psalm:


### PR DESCRIPTION
This got removed in b9736bafab32b390fa3eb36e22f7f7e75aecd767, but having CI for PRs is probably useful.