### PR TITLE
Backport ext-sodium enhancement to v2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
         phpunit-versions: ['latest']
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
         phpunit-versions: ['latest']
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           tools: phpunit:${{ matrix.phpunit-versions }}
 
       - name: Install dependencies
-        run: composer self-update; composer remove vimeo/psalm; composer install
+        run: composer self-update; composer remove --dev vimeo/psalm; composer install
 
       - name: PHPUnit tests
         run: phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           tools: phpunit:${{ matrix.phpunit-versions }}
 
       - name: Install dependencies
-        run: composer self-update; composer install
+        run: composer self-update; composer remove vimeo/psalm; composer install
 
       - name: PHPUnit tests
         run: phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           tools: phpunit:${{ matrix.phpunit-versions }}
 
       - name: Install dependencies
-        run: composer self-update --1; composer install
+        run: composer self-update; composer install
 
       - name: PHPUnit tests
         run: phpunit

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,7 @@
     "source":   "https://github.com/paragonie/constant_time_encoding"
   },
   "require": {
-    "php": "^7|^8",
-    "paragonie/sodium_compat": "^1|^2"
+    "php": "^7|^8"
   },
   "require-dev": {
     "phpunit/phpunit": "^6|^7|^8|^9",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     "source":   "https://github.com/paragonie/constant_time_encoding"
   },
   "require": {
-    "php": "^7|^8"
+    "php": "^7|^8",
+    "paragonie/sodium_compat": "^1|^2"
   },
   "require-dev": {
     "phpunit/phpunit": "^6|^7|^8|^9",

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -4,6 +4,7 @@ namespace ParagonIE\ConstantTime;
 
 use InvalidArgumentException;
 use RangeException;
+use SodiumException;
 use TypeError;
 
 /**
@@ -51,6 +52,25 @@ abstract class Base64 implements EncoderInterface
         #[\SensitiveParameter]
         string $binString
     ): string {
+        if (extension_loaded('sodium')) {
+            switch (static::class) {
+                case Base64::class:
+                    $variant = SODIUM_BASE64_VARIANT_ORIGINAL;
+                    break;
+                case Base64UrlSafe::class:
+                    $variant = SODIUM_BASE64_VARIANT_URLSAFE;
+                    break;
+                default:
+                    $variant = 0;
+            }
+            if ($variant > 0) {
+                try {
+                    return sodium_bin2base64($binString, $variant);
+                } catch (SodiumException $ex) {
+                    throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
+                }
+            }
+        }
         return static::doEncode($binString, true);
     }
 
@@ -68,6 +88,25 @@ abstract class Base64 implements EncoderInterface
         #[\SensitiveParameter]
         string $src
     ): string {
+        if (extension_loaded('sodium')) {
+            switch (static::class) {
+                case Base64::class:
+                    $variant = SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING;
+                    break;
+                case Base64UrlSafe::class:
+                    $variant = SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING;
+                    break;
+                default:
+                    $variant = 0;
+            }
+            if ($variant > 0) {
+                try {
+                    return sodium_bin2base64($src, $variant);
+                } catch (SodiumException $ex) {
+                    throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
+                }
+            }
+        }
         return static::doEncode($src, false);
     }
 
@@ -166,6 +205,23 @@ abstract class Base64 implements EncoderInterface
                 throw new RangeException(
                     'Incorrect padding'
                 );
+            }
+            switch (static::class) {
+                case Base64::class:
+                    $variant = SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING;
+                    break;
+                case Base64UrlSafe::class:
+                    $variant = SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING;
+                    break;
+                default:
+                    $variant = 0;
+            }
+            if ($variant > 0) {
+                try {
+                    return sodium_base642bin($encodedString, $variant);
+                } catch (SodiumException $ex) {
+                    throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
+                }
             }
         } else {
             $encodedString = \rtrim($encodedString, '=');

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -206,21 +206,23 @@ abstract class Base64 implements EncoderInterface
                     'Incorrect padding'
                 );
             }
-            switch (static::class) {
-                case Base64::class:
-                    $variant = SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING;
-                    break;
-                case Base64UrlSafe::class:
-                    $variant = SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING;
-                    break;
-                default:
-                    $variant = 0;
-            }
-            if ($variant > 0) {
-                try {
-                    return sodium_base642bin($encodedString, $variant);
-                } catch (SodiumException $ex) {
-                    throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
+            if (extension_loaded('sodium')) {
+                switch (static::class) {
+                    case Base64::class:
+                        $variant = SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING;
+                        break;
+                    case Base64UrlSafe::class:
+                        $variant = SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING;
+                        break;
+                    default:
+                        $variant = 0;
+                }
+                if ($variant > 0) {
+                    try {
+                        return sodium_base642bin($encodedString, $variant);
+                    } catch (SodiumException $ex) {
+                        throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
+                    }
                 }
             }
         } else {

--- a/src/Hex.php
+++ b/src/Hex.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
 use RangeException;
+use SodiumException;
 use TypeError;
 
 /**
@@ -46,6 +47,13 @@ abstract class Hex implements EncoderInterface
         #[\SensitiveParameter]
         string $binString
     ): string {
+        if (extension_loaded('sodium')) {
+            try {
+                return sodium_bin2hex($binString);
+            } catch (SodiumException $ex) {
+                throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
+            }
+        }
         $hex = '';
         $len = Binary::safeStrlen($binString);
         for ($i = 0; $i < $len; ++$i) {
@@ -107,6 +115,13 @@ abstract class Hex implements EncoderInterface
         string $encodedString,
         bool $strictPadding = false
     ): string {
+        if (extension_loaded('sodium') && $strictPadding) {
+            try {
+                return sodium_hex2bin($encodedString);
+            } catch (SodiumException $ex) {
+                throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
+            }
+        }
         $hex_pos = 0;
         $bin = '';
         $c_acc = 0;

--- a/tests/Base32Test.php
+++ b/tests/Base32Test.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace ParagonIE\ConstantTime\Tests;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Base32;
 
@@ -66,6 +67,7 @@ class Base32Test extends TestCase
     /**
      * @dataProvider canonProvider
      */
+    #[DataProvider("canonProvider")]
     public function testCanonicalBase32(string $canonical, string $munged)
     {
         Base32::decode($canonical);

--- a/tests/Base64DotSlashOrderedTest.php
+++ b/tests/Base64DotSlashOrderedTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace ParagonIE\ConstantTime\Tests;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Base64DotSlashOrdered;
 use RangeException;
@@ -50,6 +51,7 @@ class Base64DotSlashOrderedTest extends TestCase
     /**
      * @dataProvider canonicalDataProvider
      */
+    #[DataProvider("canonicalDataProvider")]
     public function testNonCanonical(string $input)
     {
         $w = Base64DotSlashOrdered::encodeUnpadded($input);

--- a/tests/Base64DotSlashTest.php
+++ b/tests/Base64DotSlashTest.php
@@ -4,6 +4,7 @@ namespace ParagonIE\ConstantTime\Tests;
 
 use InvalidArgumentException;
 use ParagonIE\ConstantTime\Base64DotSlash;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RangeException;
 
@@ -50,6 +51,7 @@ class Base64DotSlashTest extends TestCase
     /**
      * @dataProvider canonicalDataProvider
      */
+    #[DataProvider("canonicalDataProvider")]
     public function testNonCanonical(string $input)
     {
         $w = Base64DotSlash::encodeUnpadded($input);

--- a/tests/Base64Test.php
+++ b/tests/Base64Test.php
@@ -108,7 +108,8 @@ class Base64Test extends TestCase
     public function testNonCanonical(string $input)
     {
         $w = Base64::encodeUnpadded($input);
-        Base64::decode($w);
+        $decoded = Base64::decode($w);
+        $this->assertSame($input, $decoded);
         Base64::decode($w, true);
 
         // Mess with padding:

--- a/tests/Base64Test.php
+++ b/tests/Base64Test.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace ParagonIE\ConstantTime\Tests;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Base64;
 use RangeException;
@@ -105,6 +106,7 @@ class Base64Test extends TestCase
     /**
      * @dataProvider canonicalDataProvider
      */
+    #[DataProvider("canonicalDataProvider")]
     public function testNonCanonical(string $input)
     {
         $w = Base64::encodeUnpadded($input);

--- a/tests/Base64UrlSafeTest.php
+++ b/tests/Base64UrlSafeTest.php
@@ -4,6 +4,7 @@ namespace ParagonIE\ConstantTime\Tests;
 
 use Exception;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\ConstantTime\Binary;
@@ -75,6 +76,7 @@ class Base64UrlSafeTest extends TestCase
     /**
      * @dataProvider canonicalDataProvider
      */
+    #[DataProvider("canonicalDataProvider")]
     public function testNonCanonical(string $input)
     {
         $w = Base64UrlSafe::encodeUnpadded($input);

--- a/tests/Base64UrlSafeTest.php
+++ b/tests/Base64UrlSafeTest.php
@@ -78,7 +78,8 @@ class Base64UrlSafeTest extends TestCase
     public function testNonCanonical(string $input)
     {
         $w = Base64UrlSafe::encodeUnpadded($input);
-        Base64UrlSafe::decode($w);
+        $decoded = Base64UrlSafe::decode($w);
+        $this->assertSame($input, $decoded);
         Base64UrlSafe::decode($w, true);
 
         // Mess with padding:


### PR DESCRIPTION
This allows software supporting PHP 7 to gain the performance benefits of ext-sodium.