### PR TITLE
Improve sodium implementation performance

### DIFF
--- a/src/Base64.php
+++ b/src/Base64.php
@@ -53,7 +53,7 @@ abstract class Base64 implements EncoderInterface
         #[\SensitiveParameter]
         string $binString
     ): string {
-        if (extension_loaded('sodium')) {
+        if (\extension_loaded('sodium')) {
             $variant = match(static::class) {
                 Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL,
                 Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE,
@@ -85,7 +85,7 @@ abstract class Base64 implements EncoderInterface
         #[\SensitiveParameter]
         string $src
     ): string {
-        if (extension_loaded('sodium')) {
+        if (\extension_loaded('sodium')) {
             $variant = match(static::class) {
                 Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
                 Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
@@ -199,7 +199,7 @@ abstract class Base64 implements EncoderInterface
                     'Incorrect padding'
                 );
             }
-            if (extension_loaded('sodium')) {
+            if (\extension_loaded('sodium')) {
                 $variant = match(static::class) {
                     Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
                     Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -61,7 +61,7 @@ abstract class Base64 implements EncoderInterface
             };
             if ($variant > 0) {
                 try {
-                    return sodium_bin2base64($binString, $variant);
+                    return \sodium_bin2base64($binString, $variant);
                 } catch (SodiumException $ex) {
                     throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
                 }
@@ -93,7 +93,7 @@ abstract class Base64 implements EncoderInterface
             };
             if ($variant > 0) {
                 try {
-                    return sodium_bin2base64($src, $variant);
+                    return \sodium_bin2base64($src, $variant);
                 } catch (SodiumException $ex) {
                     throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
                 }
@@ -207,7 +207,7 @@ abstract class Base64 implements EncoderInterface
                 };
                 if ($variant > 0) {
                     try {
-                        return sodium_base642bin($encodedString, $variant);
+                        return \sodium_base642bin($encodedString, $variant);
                     } catch (SodiumException $ex) {
                         throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
                     }

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -55,8 +55,8 @@ abstract class Base64 implements EncoderInterface
     ): string {
         if (\extension_loaded('sodium')) {
             $variant = match(static::class) {
-                Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL,
-                Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE,
+                Base64::class => \SODIUM_BASE64_VARIANT_ORIGINAL,
+                Base64UrlSafe::class => \SODIUM_BASE64_VARIANT_URLSAFE,
                 default => 0,
             };
             if ($variant > 0) {
@@ -87,8 +87,8 @@ abstract class Base64 implements EncoderInterface
     ): string {
         if (\extension_loaded('sodium')) {
             $variant = match(static::class) {
-                Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
-                Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
+                Base64::class => \SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
+                Base64UrlSafe::class => \SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
                 default => 0,
             };
             if ($variant > 0) {
@@ -201,8 +201,8 @@ abstract class Base64 implements EncoderInterface
             }
             if (\extension_loaded('sodium')) {
                 $variant = match(static::class) {
-                    Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
-                    Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
+                    Base64::class => \SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
+                    Base64UrlSafe::class => \SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
                     default => 0,
                 };
                 if ($variant > 0) {

--- a/src/Hex.php
+++ b/src/Hex.php
@@ -50,7 +50,7 @@ abstract class Hex implements EncoderInterface
     ): string {
         if (\extension_loaded('sodium')) {
             try {
-                return sodium_bin2hex($binString);
+                return \sodium_bin2hex($binString);
             } catch (SodiumException $ex) {
                 throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
             }
@@ -119,7 +119,7 @@ abstract class Hex implements EncoderInterface
     ): string {
         if (\extension_loaded('sodium') && $strictPadding) {
             try {
-                return sodium_hex2bin($encodedString);
+                return \sodium_hex2bin($encodedString);
             } catch (SodiumException $ex) {
                 throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
             }

--- a/src/Hex.php
+++ b/src/Hex.php
@@ -48,7 +48,7 @@ abstract class Hex implements EncoderInterface
         #[\SensitiveParameter]
         string $binString
     ): string {
-        if (extension_loaded('sodium')) {
+        if (\extension_loaded('sodium')) {
             try {
                 return sodium_bin2hex($binString);
             } catch (SodiumException $ex) {
@@ -117,7 +117,7 @@ abstract class Hex implements EncoderInterface
         string $encodedString,
         bool $strictPadding = false
     ): string {
-        if (extension_loaded('sodium') && $strictPadding) {
+        if (\extension_loaded('sodium') && $strictPadding) {
             try {
                 return sodium_hex2bin($encodedString);
             } catch (SodiumException $ex) {


### PR DESCRIPTION
For the following test script:

```
<?php

require('vendor/autoload.php');

for ($i = 0; $i < 10000000; $i++) {
        \ParagonIE\ConstantTime\Hex::encode('foo');
}
```

Hyperfine reports:

```
hyperfine 'php -d opcache.enable_cli=1 constant_time_encoding/test.php' 'php -d opcache.enable_cli=1 constant_time_encoding_before/test.php'
Benchmark 1: php -d opcache.enable_cli=1 constant_time_encoding/test.php
  Time (mean ± σ):     423.1 ms ±  19.6 ms    [User: 405.6 ms, System: 17.0 ms]
  Range (min … max):   403.7 ms … 475.7 ms    10 runs
 
Benchmark 2: php -d opcache.enable_cli=1 constant_time_encoding_before/test.php
  Time (mean ± σ):     745.7 ms ±  10.3 ms    [User: 725.9 ms, System: 18.8 ms]
  Range (min … max):   731.3 ms … 759.1 ms    10 runs
 
Summary
  php -d opcache.enable_cli=1 constant_time_encoding/test.php ran
    1.76 ± 0.09 times faster than php -d opcache.enable_cli=1 constant_time_encoding_before/test.php
```