### PR TITLE
Replace qualifiers with imports

### DIFF
--- a/src/Base32.php
+++ b/src/Base32.php
@@ -3,8 +3,15 @@ declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
 use InvalidArgumentException;
+use Override;
 use RangeException;
+use SensitiveParameter;
 use TypeError;
+use function pack;
+use function rtrim;
+use function strlen;
+use function substr;
+use function unpack;
 
 /**
  *  Copyright (c) 2016 - 2022 Paragon Initiative Enterprises.
@@ -44,9 +51,9 @@ abstract class Base32 implements EncoderInterface
      * @param bool $strictPadding
      * @return string
      */
-    #[\Override]
+    #[Override]
     public static function decode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $encodedString,
         bool $strictPadding = false
     ): string {
@@ -61,7 +68,7 @@ abstract class Base32 implements EncoderInterface
      * @return string
      */
     public static function decodeUpper(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $src,
         bool $strictPadding = false
     ): string {
@@ -75,9 +82,9 @@ abstract class Base32 implements EncoderInterface
      * @return string
      * @throws TypeError
      */
-    #[\Override]
+    #[Override]
     public static function encode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $binString
     ): string {
         return static::doEncode($binString, false, true);
@@ -92,7 +99,7 @@ abstract class Base32 implements EncoderInterface
      * @api
      */
     public static function encodeUnpadded(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $src
     ): string {
         return static::doEncode($src, false, false);
@@ -107,7 +114,7 @@ abstract class Base32 implements EncoderInterface
      * @api
      */
     public static function encodeUpper(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $src
     ): string {
         return static::doEncode($src, true, true);
@@ -122,7 +129,7 @@ abstract class Base32 implements EncoderInterface
      * @api
      */
     public static function encodeUpperUnpadded(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $src
     ): string {
         return static::doEncode($src, true, false);
@@ -187,7 +194,7 @@ abstract class Base32 implements EncoderInterface
         // if ($src > 25) $ret -= 72;
         $diff -= ((25 - $src) >> 8) & 73;
 
-        return \pack('C', $src + $diff);
+        return pack('C', $src + $diff);
     }
 
     /**
@@ -207,7 +214,7 @@ abstract class Base32 implements EncoderInterface
         // if ($src > 25) $ret -= 40;
         $diff -= ((25 - $src) >> 8) & 41;
 
-        return \pack('C', $src + $diff);
+        return pack('C', $src + $diff);
     }
 
     /**
@@ -217,11 +224,11 @@ abstract class Base32 implements EncoderInterface
      * @api
      */
     public static function decodeNoPadding(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $encodedString,
         bool $upper = false
     ): string {
-        $srcLen = \strlen($encodedString);
+        $srcLen = strlen($encodedString);
         if ($srcLen === 0) {
             return '';
         }
@@ -252,7 +259,7 @@ abstract class Base32 implements EncoderInterface
      * @throws TypeError
      */
     protected static function doDecode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $src,
         bool $upper = false,
         bool $strictPadding = false
@@ -263,7 +270,7 @@ abstract class Base32 implements EncoderInterface
             : 'decode5Bits';
 
         // Remove padding
-        $srcLen = \strlen($src);
+        $srcLen = strlen($src);
         if ($srcLen === 0) {
             return '';
         }
@@ -283,8 +290,8 @@ abstract class Base32 implements EncoderInterface
                 );
             }
         } else {
-            $src = \rtrim($src, '=');
-            $srcLen = \strlen($src);
+            $src = rtrim($src, '=');
+            $srcLen = strlen($src);
         }
 
         $err = 0;
@@ -292,7 +299,7 @@ abstract class Base32 implements EncoderInterface
         // Main loop (no padding):
         for ($i = 0; $i + 8 <= $srcLen; $i += 8) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', \substr($src, $i, 8));
+            $chunk = unpack('C*', substr($src, $i, 8));
             /** @var int $c0 */
             $c0 = static::$method($chunk[1]);
             /** @var int $c1 */
@@ -310,7 +317,7 @@ abstract class Base32 implements EncoderInterface
             /** @var int $c7 */
             $c7 = static::$method($chunk[8]);
 
-            $dest .= \pack(
+            $dest .= pack(
                 'CCCCC',
                 (($c0 << 3) | ($c1 >> 2)             ) & 0xff,
                 (($c1 << 6) | ($c2 << 1) | ($c3 >> 4)) & 0xff,
@@ -323,7 +330,7 @@ abstract class Base32 implements EncoderInterface
         // The last chunk, which may have padding:
         if ($i < $srcLen) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', \substr($src, $i, $srcLen - $i));
+            $chunk = unpack('C*', substr($src, $i, $srcLen - $i));
             /** @var int $c0 */
             $c0 = static::$method($chunk[1]);
 
@@ -341,7 +348,7 @@ abstract class Base32 implements EncoderInterface
                 /** @var int $c6 */
                 $c6 = static::$method($chunk[7]);
 
-                $dest .= \pack(
+                $dest .= pack(
                     'CCCC',
                     (($c0 << 3) | ($c1 >> 2)             ) & 0xff,
                     (($c1 << 6) | ($c2 << 1) | ($c3 >> 4)) & 0xff,
@@ -364,7 +371,7 @@ abstract class Base32 implements EncoderInterface
                 /** @var int $c5 */
                 $c5 = static::$method($chunk[6]);
 
-                $dest .= \pack(
+                $dest .= pack(
                     'CCCC',
                     (($c0 << 3) | ($c1 >> 2)             ) & 0xff,
                     (($c1 << 6) | ($c2 << 1) | ($c3 >> 4)) & 0xff,
@@ -382,7 +389,7 @@ abstract class Base32 implements EncoderInterface
                 /** @var int $c4 */
                 $c4 = static::$method($chunk[5]);
 
-                $dest .= \pack(
+                $dest .= pack(
                     'CCC',
                     (($c0 << 3) | ($c1 >> 2)             ) & 0xff,
                     (($c1 << 6) | ($c2 << 1) | ($c3 >> 4)) & 0xff,
@@ -400,7 +407,7 @@ abstract class Base32 implements EncoderInterface
                 /** @var int $c3 */
                 $c3 = static::$method($chunk[4]);
 
-                $dest .= \pack(
+                $dest .= pack(
                     'CC',
                     (($c0 << 3) | ($c1 >> 2)             ) & 0xff,
                     (($c1 << 6) | ($c2 << 1) | ($c3 >> 4)) & 0xff
@@ -415,7 +422,7 @@ abstract class Base32 implements EncoderInterface
                 /** @var int $c2 */
                 $c2 = static::$method($chunk[3]);
 
-                $dest .= \pack(
+                $dest .= pack(
                     'CC',
                     (($c0 << 3) | ($c1 >> 2)             ) & 0xff,
                     (($c1 << 6) | ($c2 << 1)             ) & 0xff
@@ -428,7 +435,7 @@ abstract class Base32 implements EncoderInterface
                 /** @var int $c1 */
                 $c1 = static::$method($chunk[2]);
 
-                $dest .= \pack(
+                $dest .= pack(
                     'C',
                     (($c0 << 3) | ($c1 >> 2)             ) & 0xff
                 );
@@ -437,7 +444,7 @@ abstract class Base32 implements EncoderInterface
                     $err |= ($c1 << 6) & 0xff;
                 }
             } else {
-                $dest .= \pack(
+                $dest .= pack(
                     'C',
                     (($c0 << 3)                          ) & 0xff
                 );
@@ -463,7 +470,7 @@ abstract class Base32 implements EncoderInterface
      * @throws TypeError
      */
     protected static function doEncode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $src,
         bool $upper = false,
         bool $pad = true
@@ -474,12 +481,12 @@ abstract class Base32 implements EncoderInterface
             : 'encode5Bits';
         
         $dest = '';
-        $srcLen = \strlen($src);
+        $srcLen = strlen($src);
 
         // Main loop (no padding):
         for ($i = 0; $i + 5 <= $srcLen; $i += 5) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', \substr($src, $i, 5));
+            $chunk = unpack('C*', substr($src, $i, 5));
             $b0 = $chunk[1];
             $b1 = $chunk[2];
             $b2 = $chunk[3];
@@ -498,7 +505,7 @@ abstract class Base32 implements EncoderInterface
         // The last chunk, which may have padding:
         if ($i < $srcLen) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', \substr($src, $i, $srcLen - $i));
+            $chunk = unpack('C*', substr($src, $i, $srcLen - $i));
             $b0 = $chunk[1];
             if ($i + 3 < $srcLen) {
                 $b1 = $chunk[2];

--- a/src/Base32Hex.php
+++ b/src/Base32Hex.php
@@ -2,6 +2,9 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
+use Override;
+use function pack;
+
 /**
  *  Copyright (c) 2016 - 2022 Paragon Initiative Enterprises.
  *  Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
@@ -40,7 +43,7 @@ abstract class Base32Hex extends Base32
      * @param int $src
      * @return int
      */
-    #[\Override]
+    #[Override]
     protected static function decode5Bits(int $src): int
     {
         $ret = -1;
@@ -61,7 +64,7 @@ abstract class Base32Hex extends Base32
      * @param int $src
      * @return int
      */
-    #[\Override]
+    #[Override]
     protected static function decode5BitsUpper(int $src): int
     {
         $ret = -1;
@@ -82,7 +85,7 @@ abstract class Base32Hex extends Base32
      * @param int $src
      * @return string
      */
-    #[\Override]
+    #[Override]
     protected static function encode5Bits(int $src): string
     {
         $src += 0x30;
@@ -90,7 +93,7 @@ abstract class Base32Hex extends Base32
         // if ($src > 0x39) $src += 0x61 - 0x3a; // 39
         $src += ((0x39 - $src) >> 8) & 39;
 
-        return \pack('C', $src);
+        return pack('C', $src);
     }
 
     /**
@@ -102,7 +105,7 @@ abstract class Base32Hex extends Base32
      * @param int $src
      * @return string
      */
-    #[\Override]
+    #[Override]
     protected static function encode5BitsUpper(int $src): string
     {
         $src += 0x30;
@@ -110,6 +113,6 @@ abstract class Base32Hex extends Base32
         // if ($src > 0x39) $src += 0x41 - 0x3a; // 7
         $src += ((0x39 - $src) >> 8) & 7;
 
-        return \pack('C', $src);
+        return pack('C', $src);
     }
 }

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -3,9 +3,23 @@ declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
 use InvalidArgumentException;
+use Override;
 use RangeException;
+use SensitiveParameter;
 use SodiumException;
 use TypeError;
+use function extension_loaded;
+use function pack;
+use function rtrim;
+use function sodium_base642bin;
+use function sodium_bin2base64;
+use function strlen;
+use function substr;
+use function unpack;
+use const SODIUM_BASE64_VARIANT_ORIGINAL;
+use const SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING;
+use const SODIUM_BASE64_VARIANT_URLSAFE;
+use const SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING;
 
 /**
  *  Copyright (c) 2016 - 2022 Paragon Initiative Enterprises.
@@ -48,20 +62,20 @@ abstract class Base64 implements EncoderInterface
      *
      * @throws TypeError
      */
-    #[\Override]
+    #[Override]
     public static function encode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $binString
     ): string {
-        if (\extension_loaded('sodium')) {
+        if (extension_loaded('sodium')) {
             $variant = match(static::class) {
-                Base64::class => \SODIUM_BASE64_VARIANT_ORIGINAL,
-                Base64UrlSafe::class => \SODIUM_BASE64_VARIANT_URLSAFE,
+                Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL,
+                Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE,
                 default => 0,
             };
             if ($variant > 0) {
                 try {
-                    return \sodium_bin2base64($binString, $variant);
+                    return sodium_bin2base64($binString, $variant);
                 } catch (SodiumException $ex) {
                     throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
                 }
@@ -82,18 +96,18 @@ abstract class Base64 implements EncoderInterface
      * @api
      */
     public static function encodeUnpadded(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $src
     ): string {
-        if (\extension_loaded('sodium')) {
+        if (extension_loaded('sodium')) {
             $variant = match(static::class) {
-                Base64::class => \SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
-                Base64UrlSafe::class => \SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
+                Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
+                Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
                 default => 0,
             };
             if ($variant > 0) {
                 try {
-                    return \sodium_bin2base64($src, $variant);
+                    return sodium_bin2base64($src, $variant);
                 } catch (SodiumException $ex) {
                     throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
                 }
@@ -110,16 +124,16 @@ abstract class Base64 implements EncoderInterface
      * @throws TypeError
      */
     protected static function doEncode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $src,
         bool $pad = true
     ): string {
         $dest = '';
-        $srcLen = \strlen($src);
+        $srcLen = strlen($src);
         // Main loop (no padding):
         for ($i = 0; $i + 3 <= $srcLen; $i += 3) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', \substr($src, $i, 3));
+            $chunk = unpack('C*', substr($src, $i, 3));
             $b0 = $chunk[1];
             $b1 = $chunk[2];
             $b2 = $chunk[3];
@@ -133,7 +147,7 @@ abstract class Base64 implements EncoderInterface
         // The last chunk, which may have padding:
         if ($i < $srcLen) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', \substr($src, $i, $srcLen - $i));
+            $chunk = unpack('C*', substr($src, $i, $srcLen - $i));
             $b0 = $chunk[1];
             if ($i + 1 < $srcLen) {
                 $b1 = $chunk[2];
@@ -168,14 +182,14 @@ abstract class Base64 implements EncoderInterface
      * @throws RangeException
      * @throws TypeError
      */
-    #[\Override]
+    #[Override]
     public static function decode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $encodedString,
         bool $strictPadding = false
     ): string {
         // Remove padding
-        $srcLen = \strlen($encodedString);
+        $srcLen = strlen($encodedString);
         if ($srcLen === 0) {
             return '';
         }
@@ -199,23 +213,23 @@ abstract class Base64 implements EncoderInterface
                     'Incorrect padding'
                 );
             }
-            if (\extension_loaded('sodium')) {
+            if (extension_loaded('sodium')) {
                 $variant = match(static::class) {
-                    Base64::class => \SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
-                    Base64UrlSafe::class => \SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
+                    Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
+                    Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
                     default => 0,
                 };
                 if ($variant > 0) {
                     try {
-                        return \sodium_base642bin($encodedString, $variant);
+                        return sodium_base642bin($encodedString, $variant);
                     } catch (SodiumException $ex) {
                         throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
                     }
                 }
             }
         } else {
-            $encodedString = \rtrim($encodedString, '=');
-            $srcLen = \strlen($encodedString);
+            $encodedString = rtrim($encodedString, '=');
+            $srcLen = strlen($encodedString);
         }
 
         $err = 0;
@@ -223,13 +237,13 @@ abstract class Base64 implements EncoderInterface
         // Main loop (no padding):
         for ($i = 0; $i + 4 <= $srcLen; $i += 4) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', \substr($encodedString, $i, 4));
+            $chunk = unpack('C*', substr($encodedString, $i, 4));
             $c0 = static::decode6Bits($chunk[1]);
             $c1 = static::decode6Bits($chunk[2]);
             $c2 = static::decode6Bits($chunk[3]);
             $c3 = static::decode6Bits($chunk[4]);
 
-            $dest .= \pack(
+            $dest .= pack(
                 'CCC',
                 ((($c0 << 2) | ($c1 >> 4)) & 0xff),
                 ((($c1 << 4) | ($c2 >> 2)) & 0xff),
@@ -240,13 +254,13 @@ abstract class Base64 implements EncoderInterface
         // The last chunk, which may have padding:
         if ($i < $srcLen) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C*', \substr($encodedString, $i, $srcLen - $i));
+            $chunk = unpack('C*', substr($encodedString, $i, $srcLen - $i));
             $c0 = static::decode6Bits($chunk[1]);
 
             if ($i + 2 < $srcLen) {
                 $c1 = static::decode6Bits($chunk[2]);
                 $c2 = static::decode6Bits($chunk[3]);
-                $dest .= \pack(
+                $dest .= pack(
                     'CC',
                     ((($c0 << 2) | ($c1 >> 4)) & 0xff),
                     ((($c1 << 4) | ($c2 >> 2)) & 0xff)
@@ -257,7 +271,7 @@ abstract class Base64 implements EncoderInterface
                 }
             } elseif ($i + 1 < $srcLen) {
                 $c1 = static::decode6Bits($chunk[2]);
-                $dest .= \pack(
+                $dest .= pack(
                     'C',
                     ((($c0 << 2) | ($c1 >> 4)) & 0xff)
                 );
@@ -284,10 +298,10 @@ abstract class Base64 implements EncoderInterface
      * @api
      */
     public static function decodeNoPadding(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $encodedString
     ): string {
-        $srcLen = \strlen($encodedString);
+        $srcLen = strlen($encodedString);
         if ($srcLen === 0) {
             return '';
         }
@@ -361,6 +375,6 @@ abstract class Base64 implements EncoderInterface
         // if ($src > 62) $diff += 0x2f - 0x2b - 1; // 3
         $diff += ((62 - $src) >> 8) & 3;
 
-        return \pack('C', $src + $diff);
+        return pack('C', $src + $diff);
     }
 }

--- a/src/Base64DotSlash.php
+++ b/src/Base64DotSlash.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
+use Override;
+
 /**
  *  Copyright (c) 2016 - 2022 Paragon Initiative Enterprises.
  *  Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
@@ -44,7 +46,7 @@ abstract class Base64DotSlash extends Base64
      * @param int $src
      * @return int
      */
-    #[\Override]
+    #[Override]
     protected static function decode6Bits(int $src): int
     {
         $ret = -1;
@@ -71,7 +73,7 @@ abstract class Base64DotSlash extends Base64
      * @param int $src
      * @return string
      */
-    #[\Override]
+    #[Override]
     protected static function encode6Bits(int $src): string
     {
         $src += 0x2e;

--- a/src/Base64DotSlashOrdered.php
+++ b/src/Base64DotSlashOrdered.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
+use Override;
+
 /**
  *  Copyright (c) 2016 - 2022 Paragon Initiative Enterprises.
  *  Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
@@ -44,7 +46,7 @@ abstract class Base64DotSlashOrdered extends Base64
      * @param int $src
      * @return int
      */
-    #[\Override]
+    #[Override]
     protected static function decode6Bits(int $src): int
     {
         $ret = -1;
@@ -68,7 +70,7 @@ abstract class Base64DotSlashOrdered extends Base64
      * @param int $src
      * @return string
      */
-    #[\Override]
+    #[Override]
     protected static function encode6Bits(int $src): string
     {
         $src += 0x2e;

--- a/src/Base64UrlSafe.php
+++ b/src/Base64UrlSafe.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
+use Override;
+
 /**
  *  Copyright (c) 2016 - 2022 Paragon Initiative Enterprises.
  *  Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
@@ -45,7 +47,7 @@ abstract class Base64UrlSafe extends Base64
      * @param int $src
      * @return int
      */
-    #[\Override]
+    #[Override]
     protected static function decode6Bits(int $src): int
     {
         $ret = -1;
@@ -75,7 +77,7 @@ abstract class Base64UrlSafe extends Base64
      * @param int $src
      * @return string
      */
-    #[\Override]
+    #[Override]
     protected static function encode6Bits(int $src): string
     {
         $diff = 0x41;

--- a/src/Binary.php
+++ b/src/Binary.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
+use SensitiveParameter;
 use TypeError;
+use function strlen;
+use function substr;
 
 /**
  *  Copyright (c) 2016 - 2022 Paragon Initiative Enterprises.
@@ -46,10 +49,10 @@ abstract class Binary
      * @return int
      */
     public static function safeStrlen(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): int {
-        return \strlen($str);
+        return strlen($str);
     }
 
     /**
@@ -66,7 +69,7 @@ abstract class Binary
      * @throws TypeError
      */
     public static function safeSubstr(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str,
         int $start = 0,
         ?int $length = null
@@ -76,9 +79,9 @@ abstract class Binary
         }
         // Unlike mb_substr(), substr() doesn't accept NULL for length
         if ($length !== null) {
-            return \substr($str, $start, $length);
+            return substr($str, $start, $length);
         } else {
-            return \substr($str, $start);
+            return substr($str, $start);
         }
     }
 }

--- a/src/EncoderInterface.php
+++ b/src/EncoderInterface.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
+use SensitiveParameter;
+
 /**
  *  Copyright (c) 2016 - 2022 Paragon Initiative Enterprises.
  *  Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
@@ -39,7 +41,7 @@ interface EncoderInterface
      * @return string
      */
     public static function encode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $binString
     ): string;
 
@@ -52,7 +54,7 @@ interface EncoderInterface
      * @return string (raw binary)
      */
     public static function decode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $encodedString,
         bool $strictPadding = false
     ): string;

--- a/src/Encoding.php
+++ b/src/Encoding.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
+use RangeException;
+use SensitiveParameter;
 use TypeError;
 
 /**
@@ -42,7 +44,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base32Encode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32::encode($str);
@@ -56,7 +58,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base32EncodeUpper(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32::encodeUpper($str);
@@ -70,7 +72,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base32Decode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32::decode($str);
@@ -84,7 +86,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base32DecodeUpper(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32::decodeUpper($str);
@@ -98,7 +100,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base32HexEncode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32Hex::encode($str);
@@ -112,7 +114,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base32HexEncodeUpper(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32Hex::encodeUpper($str);
@@ -126,7 +128,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base32HexDecode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32Hex::decode($str);
@@ -140,7 +142,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base32HexDecodeUpper(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32Hex::decodeUpper($str);
@@ -154,7 +156,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base64Encode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base64::encode($str);
@@ -168,7 +170,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base64Decode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base64::decode($str);
@@ -183,7 +185,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base64EncodeDotSlash(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base64DotSlash::encode($str);
@@ -196,11 +198,11 @@ abstract class Encoding
      *
      * @param string $str
      * @return string
-     * @throws \RangeException
+     * @throws RangeException
      * @throws TypeError
      */
     public static function base64DecodeDotSlash(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base64DotSlash::decode($str);
@@ -215,7 +217,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function base64EncodeDotSlashOrdered(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base64DotSlashOrdered::encode($str);
@@ -228,11 +230,11 @@ abstract class Encoding
      *
      * @param string $str
      * @return string
-     * @throws \RangeException
+     * @throws RangeException
      * @throws TypeError
      */
     public static function base64DecodeDotSlashOrdered(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base64DotSlashOrdered::decode($str);
@@ -247,7 +249,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function hexEncode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $bin_string
     ): string {
         return Hex::encode($bin_string);
@@ -259,10 +261,10 @@ abstract class Encoding
      *
      * @param string $hex_string
      * @return string (raw binary)
-     * @throws \RangeException
+     * @throws RangeException
      */
     public static function hexDecode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $hex_string
     ): string {
         return Hex::decode($hex_string);
@@ -277,7 +279,7 @@ abstract class Encoding
      * @throws TypeError
      */
     public static function hexEncodeUpper(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $bin_string
     ): string {
         return Hex::encodeUpper($bin_string);
@@ -291,7 +293,7 @@ abstract class Encoding
      * @return string
      */
     public static function hexDecodeUpper(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $bin_string
     ): string {
         return Hex::decode($bin_string);

--- a/src/Hex.php
+++ b/src/Hex.php
@@ -2,12 +2,20 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
+use Override;
 use RangeException;
+use SensitiveParameter;
 use SodiumException;
 use TypeError;
+use function extension_loaded;
+use function pack;
+use function sodium_bin2hex;
+use function sodium_hex2bin;
+use function strlen;
+use function unpack;
 
 /**
- *  Copyright (c) 2016 - 2022 Paragon Initiative Enterprises.
+ *  Copyright (c) 2016 - 2025 Paragon Initiative Enterprises.
  *  Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -43,27 +51,27 @@ abstract class Hex implements EncoderInterface
      * @return string
      * @throws TypeError
      */
-    #[\Override]
+    #[Override]
     public static function encode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $binString
     ): string {
-        if (\extension_loaded('sodium')) {
+        if (extension_loaded('sodium')) {
             try {
-                return \sodium_bin2hex($binString);
+                return sodium_bin2hex($binString);
             } catch (SodiumException $ex) {
                 throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
             }
         }
         $hex = '';
-        $len = \strlen($binString);
+        $len = strlen($binString);
         for ($i = 0; $i < $len; ++$i) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C', $binString[$i]);
+            $chunk = unpack('C', $binString[$i]);
             $c = $chunk[1] & 0xf;
             $b = $chunk[1] >> 4;
 
-            $hex .= \pack(
+            $hex .= pack(
                 'CC',
                 (87 + $b + ((($b - 10) >> 8) & ~38)),
                 (87 + $c + ((($c - 10) >> 8) & ~38))
@@ -81,19 +89,19 @@ abstract class Hex implements EncoderInterface
      * @throws TypeError
      */
     public static function encodeUpper(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $binString
     ): string {
         $hex = '';
-        $len = \strlen($binString);
+        $len = strlen($binString);
 
         for ($i = 0; $i < $len; ++$i) {
             /** @var array<int, int> $chunk */
-            $chunk = \unpack('C', $binString[$i]);
+            $chunk = unpack('C', $binString[$i]);
             $c = $chunk[1] & 0xf;
             $b = $chunk[1] >> 4;
 
-            $hex .= \pack(
+            $hex .= pack(
                 'CC',
                 (55 + $b + ((($b - 10) >> 8) & ~6)),
                 (55 + $c + ((($c - 10) >> 8) & ~6))
@@ -111,15 +119,15 @@ abstract class Hex implements EncoderInterface
      * @return string (raw binary)
      * @throws RangeException
      */
-    #[\Override]
+    #[Override]
     public static function decode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $encodedString,
         bool $strictPadding = false
     ): string {
-        if (\extension_loaded('sodium') && $strictPadding) {
+        if (extension_loaded('sodium') && $strictPadding) {
             try {
-                return \sodium_hex2bin($encodedString);
+                return sodium_hex2bin($encodedString);
             } catch (SodiumException $ex) {
                 throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
             }
@@ -127,7 +135,7 @@ abstract class Hex implements EncoderInterface
         $hex_pos = 0;
         $bin = '';
         $c_acc = 0;
-        $hex_len = \strlen($encodedString);
+        $hex_len = strlen($encodedString);
         $state = 0;
         if (($hex_len & 1) !== 0) {
             if ($strictPadding) {
@@ -141,7 +149,7 @@ abstract class Hex implements EncoderInterface
         }
 
         /** @var array<int, int> $chunk */
-        $chunk = \unpack('C*', $encodedString);
+        $chunk = unpack('C*', $encodedString);
         while ($hex_pos < $hex_len) {
             ++$hex_pos;
             $c = $chunk[$hex_pos];
@@ -159,7 +167,7 @@ abstract class Hex implements EncoderInterface
             if ($state === 0) {
                 $c_acc = $c_val * 16;
             } else {
-                $bin .= \pack('C', $c_acc | $c_val);
+                $bin .= pack('C', $c_acc | $c_val);
             }
             $state ^= 1;
         }

--- a/src/RFC4648.php
+++ b/src/RFC4648.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime;
 
+use SensitiveParameter;
 use TypeError;
 
 /**
@@ -48,7 +49,7 @@ abstract class RFC4648
      * @throws TypeError
      */
     public static function base64Encode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base64::encode($str);
@@ -65,7 +66,7 @@ abstract class RFC4648
      * @throws TypeError
      */
     public static function base64Decode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base64::decode($str, true);
@@ -82,7 +83,7 @@ abstract class RFC4648
      * @throws TypeError
      */
     public static function base64UrlSafeEncode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base64UrlSafe::encode($str);
@@ -99,7 +100,7 @@ abstract class RFC4648
      * @throws TypeError
      */
     public static function base64UrlSafeDecode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base64UrlSafe::decode($str, true);
@@ -116,7 +117,7 @@ abstract class RFC4648
      * @throws TypeError
      */
     public static function base32Encode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32::encodeUpper($str);
@@ -133,7 +134,7 @@ abstract class RFC4648
      * @throws TypeError
      */
     public static function base32Decode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32::decodeUpper($str, true);
@@ -150,7 +151,7 @@ abstract class RFC4648
      * @throws TypeError
      */
     public static function base32HexEncode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32::encodeUpper($str);
@@ -167,7 +168,7 @@ abstract class RFC4648
      * @throws TypeError
      */
     public static function base32HexDecode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Base32::decodeUpper($str, true);
@@ -184,7 +185,7 @@ abstract class RFC4648
      * @throws TypeError
      */
     public static function base16Encode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Hex::encodeUpper($str);
@@ -199,7 +200,7 @@ abstract class RFC4648
      * @return string
      */
     public static function base16Decode(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $str
     ): string {
         return Hex::decode($str, true);

--- a/tests/Base32HexTest.php
+++ b/tests/Base32HexTest.php
@@ -7,6 +7,9 @@ use ParagonIE\ConstantTime\Base32Hex;
 use ParagonIE\ConstantTime\Binary;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use RangeException;
+use function random_bytes;
+use function rtrim;
 
 class Base32HexTest extends TestCase
 {
@@ -14,14 +17,14 @@ class Base32HexTest extends TestCase
     {
         for ($i = 1; $i < 32; ++$i) {
             for ($j = 0; $j < 50; ++$j) {
-                $random = \random_bytes($i);
+                $random = random_bytes($i);
 
                 $enc = Base32Hex::encode($random);
                 $this->assertSame(
                     $random,
                     Base32Hex::decode($enc)
                 );
-                $unpadded = \rtrim($enc, '=');
+                $unpadded = rtrim($enc, '=');
                 $this->assertSame(
                     $unpadded,
                     Base32Hex::encodeUnpadded($random)
@@ -35,7 +38,7 @@ class Base32HexTest extends TestCase
                 $this->assertSame(
                     $random,
                     Base32Hex::decodeUpper($enc)
-                );                $unpadded = \rtrim($enc, '=');
+                );                $unpadded = rtrim($enc, '=');
                 $this->assertSame(
                     $unpadded,
                     Base32Hex::encodeUpperUnpadded($random)
@@ -51,7 +54,7 @@ class Base32HexTest extends TestCase
     public function testUnpadded()
     {
         for ($i = 1; $i < 32; ++$i) {
-            $random = \random_bytes($i);
+            $random = random_bytes($i);
             $encoded = Base32Hex::encodeUnpadded($random);
             $decoded = Base32Hex::decodeNoPadding($encoded);
             $this->assertSame(
@@ -87,7 +90,7 @@ class Base32HexTest extends TestCase
     #[DataProvider("invalidCharactersProvider")]
     public function testInvalidCharacters(string $encoded)
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base32Hex::decode($encoded);
     }
 
@@ -97,7 +100,7 @@ class Base32HexTest extends TestCase
     #[DataProvider("invalidCharactersProvider")]
     public function testInvalidCharactersUpper(string $encoded)
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base32Hex::decodeUpper(strtoupper($encoded));
     }
 }

--- a/tests/Base32Test.php
+++ b/tests/Base32Test.php
@@ -6,6 +6,9 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Base32;
+use RangeException;
+use function random_bytes;
+use function rtrim;
 
 class Base32Test extends TestCase
 {
@@ -13,14 +16,14 @@ class Base32Test extends TestCase
     {
         for ($i = 1; $i < 32; ++$i) {
             for ($j = 0; $j < 50; ++$j) {
-                $random = \random_bytes($i);
+                $random = random_bytes($i);
 
                 $enc = Base32::encode($random);
                 $this->assertSame(
                     $random,
                     Base32::decode($enc)
                 );
-                $unpadded = \rtrim($enc, '=');
+                $unpadded = rtrim($enc, '=');
                 $this->assertSame(
                     $unpadded,
                     Base32::encodeUnpadded($random)
@@ -35,7 +38,7 @@ class Base32Test extends TestCase
                     $random,
                     Base32::decodeUpper($enc)
                 );
-                $unpadded = \rtrim($enc, '=');
+                $unpadded = rtrim($enc, '=');
                 $this->assertSame(
                     $unpadded,
                     Base32::encodeUpperUnpadded($random)
@@ -66,7 +69,7 @@ class Base32Test extends TestCase
     public function testCanonicalBase32(string $canonical, string $munged)
     {
         Base32::decode($canonical);
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base32::decodeNoPadding($munged);
     }
 
@@ -106,7 +109,7 @@ class Base32Test extends TestCase
 
     public function testDecodeNoPaddingInvalidLength()
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base32::decodeNoPadding('M');
     }
 
@@ -144,7 +147,7 @@ class Base32Test extends TestCase
     #[DataProvider("invalidStrictPaddingProvider")]
     public function testInvalidStrictPadding(string $encoded): void
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base32::decode($encoded, true);
     }
 
@@ -154,7 +157,7 @@ class Base32Test extends TestCase
     #[DataProvider("invalidStrictPaddingProvider")]
     public function testInvalidStrictPaddingUpper(string $encoded): void
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base32::decodeUpper($encoded, true);
     }
 
@@ -178,7 +181,7 @@ class Base32Test extends TestCase
     #[DataProvider("invalidCharactersProvider")]
     public function testInvalidCharacters(string $encoded): void
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base32::decode($encoded);
     }
 
@@ -188,19 +191,19 @@ class Base32Test extends TestCase
     #[DataProvider("invalidCharactersProvider")]
     public function testInvalidCharactersUpper(string $encoded): void
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base32::decodeUpper(strtoupper($encoded));
     }
 
     public function testSingleInvalidCharacter(): void
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base32::decode('aaaaaaaa`aaaaaaa');
     }
 
     public function testInvalidPaddingBits(): void
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         // Last 3 bits of last char should be 0
         Base32::decode('999999J=', true);
     }

--- a/tests/Base64DotSlashOrderedTest.php
+++ b/tests/Base64DotSlashOrderedTest.php
@@ -2,12 +2,13 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime\Tests;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Base64DotSlashOrdered;
-use ParagonIE\ConstantTime\Binary;
 use RangeException;
+use function bin2hex;
+use function random_bytes;
+use function rtrim;
 
 class Base64DotSlashOrderedTest extends TestCase
 {
@@ -17,7 +18,7 @@ class Base64DotSlashOrderedTest extends TestCase
     {
         for ($i = 1; $i < 32; ++$i) {
             for ($j = 0; $j < 50; ++$j) {
-                $random = \random_bytes($i);
+                $random = random_bytes($i);
 
                 $enc = Base64DotSlashOrdered::encode($random);
                 $this->assertSame(
@@ -25,7 +26,7 @@ class Base64DotSlashOrderedTest extends TestCase
                     Base64DotSlashOrdered::decode($enc)
                 );
 
-                $unpadded = \rtrim($enc, '=');
+                $unpadded = rtrim($enc, '=');
                 $this->assertSame(
                     $random,
                     Base64DotSlashOrdered::decode($unpadded)
@@ -41,12 +42,12 @@ class Base64DotSlashOrderedTest extends TestCase
     public function testUnpadded()
     {
         for ($i = 1; $i < 32; ++$i) {
-            $random = \random_bytes($i);
+            $random = random_bytes($i);
             $encoded = Base64DotSlashOrdered::encodeUnpadded($random);
             $decoded = Base64DotSlashOrdered::decodeNoPadding($encoded);
             $this->assertSame(
-                \bin2hex($random),
-                \bin2hex($decoded)
+                bin2hex($random),
+                bin2hex($decoded)
             );
         }
     }
@@ -95,7 +96,7 @@ class Base64DotSlashOrderedTest extends TestCase
     #[DataProvider("invalidCharactersProvider")]
     public function testInvalidCharacters(string $encoded)
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base64DotSlashOrdered::decode($encoded);
     }
 }

--- a/tests/Base64DotSlashTest.php
+++ b/tests/Base64DotSlashTest.php
@@ -2,12 +2,13 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime\Tests;
 
-use InvalidArgumentException;
 use ParagonIE\ConstantTime\Base64DotSlash;
-use ParagonIE\ConstantTime\Binary;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RangeException;
+use function bin2hex;
+use function random_bytes;
+use function rtrim;
 
 class Base64DotSlashTest extends TestCase
 {
@@ -17,7 +18,7 @@ class Base64DotSlashTest extends TestCase
     {
         for ($i = 1; $i < 32; ++$i) {
             for ($j = 0; $j < 50; ++$j) {
-                $random = \random_bytes($i);
+                $random = random_bytes($i);
 
                 $enc = Base64DotSlash::encode($random);
                 $this->assertSame(
@@ -25,7 +26,7 @@ class Base64DotSlashTest extends TestCase
                     Base64DotSlash::decode($enc)
                 );
 
-                $unpadded = \rtrim($enc, '=');
+                $unpadded = rtrim($enc, '=');
                 $this->assertSame(
                     $random,
                     Base64DotSlash::decode($unpadded)
@@ -41,12 +42,12 @@ class Base64DotSlashTest extends TestCase
     public function testUnpadded()
     {
         for ($i = 1; $i < 32; ++$i) {
-            $random = \random_bytes($i);
+            $random = random_bytes($i);
             $encoded = Base64DotSlash::encodeUnpadded($random);
             $decoded = Base64DotSlash::decodeNoPadding($encoded);
             $this->assertSame(
-                \bin2hex($random),
-                \bin2hex($decoded)
+                bin2hex($random),
+                bin2hex($decoded)
             );
         }
     }
@@ -95,7 +96,7 @@ class Base64DotSlashTest extends TestCase
     #[DataProvider("invalidCharactersProvider")]
     public function testInvalidCharacters(string $encoded)
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base64DotSlash::decode($encoded);
     }
 }

--- a/tests/Base64Test.php
+++ b/tests/Base64Test.php
@@ -2,21 +2,30 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime\Tests;
 
+use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Base64;
 use RangeException;
+use function base64_decode;
+use function base64_encode;
+use function bin2hex;
+use function random_bytes;
+use function rtrim;
 
 class Base64Test extends TestCase
 {
     use CanonicalTrait;
 
-    public function testRandom()
+    /**
+     * @throws Exception
+     */
+    public function testRandom(): void
     {
         for ($i = 1; $i < 32; ++$i) {
             for ($j = 0; $j < 50; ++$j) {
-                $random = \random_bytes($i);
+                $random = random_bytes($i);
 
                 $enc = Base64::encode($random);
                 $this->assertSame(
@@ -24,11 +33,11 @@ class Base64Test extends TestCase
                     Base64::decode($enc)
                 );
                 $this->assertSame(
-                    \base64_encode($random),
+                    base64_encode($random),
                     $enc
                 );
 
-                $unpadded = \rtrim($enc, '=');
+                $unpadded = rtrim($enc, '=');
                 $this->assertSame(
                     $random,
                     Base64::decode($unpadded)
@@ -73,16 +82,15 @@ class Base64Test extends TestCase
         try {
             Base64::decode($str, true);
             $this->fail('Strict padding not enforced');
-        } catch (\Exception $ex) {
-
+        } catch (Exception ) {
             $this->assertSame(
                 Base64::decode($str),
-                \base64_decode($str)
+                base64_decode($str)
             );
         }
     }
 
-    public function testIssue22()
+    public function testIssue22(): void
     {
         // Non-strict: ok
         Base64::decode('00==');
@@ -92,7 +100,7 @@ class Base64Test extends TestCase
         Base64::decode('00==', true);
     }
 
-    public function testDecodeNoPadding()
+    public function testDecodeNoPadding(): void
     {
         Base64::decodeNoPadding('0w');
         $this->expectException(InvalidArgumentException::class);
@@ -132,12 +140,12 @@ class Base64Test extends TestCase
     public function testUnpadded()
     {
         for ($i = 1; $i < 32; ++$i) {
-            $random = \random_bytes($i);
+            $random = random_bytes($i);
             $encoded = Base64::encodeUnpadded($random);
             $decoded = Base64::decodeNoPadding($encoded);
             $this->assertSame(
-                \bin2hex($random),
-                \bin2hex($decoded)
+                bin2hex($random),
+                bin2hex($decoded)
             );
         }
     }
@@ -158,7 +166,7 @@ class Base64Test extends TestCase
     #[DataProvider("invalidCharactersProvider")]
     public function testInvalidCharacters(string $encoded)
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base64::decode($encoded);
     }
 }

--- a/tests/Base64UrlSafeTest.php
+++ b/tests/Base64UrlSafeTest.php
@@ -3,12 +3,17 @@ declare(strict_types=1);
 namespace ParagonIE\ConstantTime\Tests;
 
 use Exception;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use RangeException;
 use TypeError;
+use function base64_encode;
+use function bin2hex;
+use function random_bytes;
+use function rtrim;
+use function strlen;
+use function strtr;
 
 class Base64UrlSafeTest extends TestCase
 {
@@ -18,11 +23,11 @@ class Base64UrlSafeTest extends TestCase
      * @throws Exception
      * @throws TypeError
      */
-    public function testRandom()
+    public function testRandom(): void
     {
         for ($i = 1; $i < 32; ++$i) {
             for ($j = 0; $j < 50; ++$j) {
-                $random = \random_bytes($i);
+                $random = random_bytes($i);
 
                 $enc = Base64UrlSafe::encode($random);
                 $this->assertSame(
@@ -30,11 +35,11 @@ class Base64UrlSafeTest extends TestCase
                     Base64UrlSafe::decode($enc)
                 );
                 $this->assertSame(
-                    \strtr(\base64_encode($random), '+/', '-_'),
+                    strtr(base64_encode($random), '+/', '-_'),
                     $enc
                 );
 
-                $unpadded = \rtrim($enc, '=');
+                $unpadded = rtrim($enc, '=');
                 $this->assertSame(
                     $unpadded,
                     Base64UrlSafe::encodeUnpadded($random)
@@ -46,28 +51,31 @@ class Base64UrlSafeTest extends TestCase
             }
         }
 
-        $random = \random_bytes(1 << 20);
+        $random = random_bytes(1 << 20);
         $enc = Base64UrlSafe::encode($random);
-        $this->assertTrue(\strlen($enc) > 65536);
+        $this->assertTrue(strlen($enc) > 65536);
         $this->assertSame(
             $random,
             Base64UrlSafe::decode($enc)
         );
         $this->assertSame(
-            \strtr(\base64_encode($random), '+/', '-_'),
+            strtr(base64_encode($random), '+/', '-_'),
             $enc
         );
     }
 
+    /**
+     * @throws Exception
+     */
     public function testUnpadded(): void
     {
         for ($i = 1; $i < 32; ++$i) {
-            $random = \random_bytes($i);
+            $random = random_bytes($i);
             $encoded = Base64UrlSafe::encodeUnpadded($random);
             $decoded = Base64UrlSafe::decodeNoPadding($encoded);
             $this->assertSame(
-                \bin2hex($random),
-                \bin2hex($decoded)
+                bin2hex($random),
+                bin2hex($decoded)
             );
         }
     }
@@ -118,7 +126,7 @@ class Base64UrlSafeTest extends TestCase
     #[DataProvider("invalidCharactersProvider")]
     public function testInvalidCharacters(string $encoded)
     {
-        $this->expectException(\RangeException::class);
+        $this->expectException(RangeException::class);
         Base64UrlSafe::decode($encoded);
     }
 }

--- a/tests/CanonicalTrait.php
+++ b/tests/CanonicalTrait.php
@@ -2,6 +2,9 @@
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime\Tests;
 
+use function strlen;
+use function substr;
+
 trait CanonicalTrait
 {
     public static function canonicalDataProvider(): array
@@ -20,8 +23,8 @@ trait CanonicalTrait
 
     protected function increment(string $str): string
     {
-        $i = \strlen($str) - 1;
+        $i = strlen($str) - 1;
         $c = $this->getNextChar($str[$i]);
-        return \substr($str, 0, $i) . $c;
+        return substr($str, 0, $i) . $c;
     }
 }

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -1,17 +1,22 @@
 <?php
 declare(strict_types=1);
 namespace ParagonIE\ConstantTime\Tests;
-use PHPUnit\Framework\TestCase;
 
+use Exception;
+use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Base32;
 use ParagonIE\ConstantTime\Base32Hex;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\ConstantTime\Encoding;
 use ParagonIE\ConstantTime\Hex;
+use function base64_encode;
+use function bin2hex;
+use function random_bytes;
+use function strtr;
 
 class EncodingTest extends TestCase
 {
-    public function testBase32Encode()
+    public function testBase32Encode(): void
     {
         $this->assertSame(
             Encoding::base32Encode("\x00"),
@@ -89,7 +94,7 @@ class EncodingTest extends TestCase
         );
     }
 
-    public function testBase32Hex()
+    public function testBase32Hex(): void
     {
         $this->assertSame(
             Base32Hex::encode("\x00"),
@@ -126,7 +131,7 @@ class EncodingTest extends TestCase
     /**
      * Based on test vectors from RFC 4648
      */
-    public function testBase32Decode()
+    public function testBase32Decode(): void
     {
         $this->assertSame(
             "\x00\x00\x00\x00\x00\x00",
@@ -202,7 +207,7 @@ class EncodingTest extends TestCase
         );
     }
 
-    public function testBasicEncoding()
+    public function testBasicEncoding(): void
     {
         // Re-run the test at least 3 times for each length
         for ($j = 0; $j < 3; ++$j) {
@@ -210,7 +215,7 @@ class EncodingTest extends TestCase
                 $rand = random_bytes($i);
                 $enc = Encoding::hexEncode($rand);
                 $this->assertSame(
-                    \bin2hex($rand),
+                    bin2hex($rand),
                     $enc,
                     "Hex Encoding - Length: " . $i
                 );
@@ -223,7 +228,7 @@ class EncodingTest extends TestCase
                 // Uppercase variant:
                 $enc = Hex::encodeUpper($rand);
                 $this->assertSame(
-                    \strtoupper(\bin2hex($rand)),
+                    \strtoupper(bin2hex($rand)),
                     $enc,
                     "Hex Encoding - Length: " . $i
                 );
@@ -283,7 +288,7 @@ class EncodingTest extends TestCase
 
                 $enc = Base64UrlSafe::encode($rand);
                 $this->assertSame(
-                    \strtr(\base64_encode($rand), '+/', '-_'),
+                    strtr(base64_encode($rand), '+/', '-_'),
                     $enc
                 );
                 $this->assertSame(
@@ -294,6 +299,9 @@ class EncodingTest extends TestCase
         }
     }
 
+    /**
+     * @throws Exception
+     */
     public function testHex(): void
     {
         for ($i = 1; $i < 32; ++$i) {

--- a/tests/HexTest.php
+++ b/tests/HexTest.php
@@ -4,6 +4,8 @@ namespace ParagonIE\ConstantTime\Tests;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ParagonIE\ConstantTime\Hex;
+use function bin2hex;
+use function strtoupper;
 
 class HexTest extends TestCase
 {
@@ -19,7 +21,7 @@ class HexTest extends TestCase
                     Hex::decode($enc)
                 );
                 $this->assertSame(
-                    \bin2hex($random),
+                    bin2hex($random),
                     $enc
                 );
 
@@ -29,7 +31,7 @@ class HexTest extends TestCase
                     Hex::decode($enc)
                 );
                 $this->assertSame(
-                    \strtoupper(\bin2hex($random)),
+                    strtoupper(bin2hex($random)),
                     $enc
                 );
             }

--- a/tests/RFC4648Test.php
+++ b/tests/RFC4648Test.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 class RFC4648Test extends TestCase
 {
-    public function testVectorBase64()
+    public function testVectorBase64(): void
     {
         $this->assertSame(Base64::encode(''), '');
         $this->assertSame(Base64::encode('f'), 'Zg==');
@@ -26,7 +26,7 @@ class RFC4648Test extends TestCase
         $this->assertSame(Base64::encode('foobar'), 'Zm9vYmFy');
     }
 
-    public function testVectorBase32()
+    public function testVectorBase32(): void
     {
         $this->assertSame(Base32::encode(''), '');
         $this->assertSame(Base32::encode('f'), 'my======');
@@ -45,7 +45,7 @@ class RFC4648Test extends TestCase
         $this->assertSame(Base32::encodeUpper('foobar'), 'MZXW6YTBOI======');
     }
 
-    public function testVectorBase32Hex()
+    public function testVectorBase32Hex(): void
     {
         $this->assertSame(Base32Hex::encode(''), '');
         $this->assertSame(Base32Hex::encode('f'), 'co======');
@@ -64,7 +64,7 @@ class RFC4648Test extends TestCase
         $this->assertSame(Base32Hex::encodeUpper('foobar'), 'CPNMUOJ1E8======');
     }
 
-    public function testVectorBase16()
+    public function testVectorBase16(): void
     {
         $this->assertSame(Hex::encode(''), '');
         $this->assertSame(Hex::encode('f'), '66');


### PR DESCRIPTION
Looking over our internal docs, we decided to move towards `use` statements instead of `\` prefixing, for purely aesthetic reasons.