### PR TITLE
FIX: Trim padding characters from encoded string before calling sodium decode

### DIFF
--- a/src/Base64.php
+++ b/src/Base64.php
@@ -213,23 +213,24 @@ abstract class Base64 implements EncoderInterface
                     'Incorrect padding'
                 );
             }
-            if (extension_loaded('sodium')) {
-                $variant = match(static::class) {
-                    Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
-                    Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
-                    default => 0,
-                };
-                if ($variant > 0) {
-                    try {
-                        return sodium_base642bin(\rtrim($encodedString, '='), $variant);
-                    } catch (SodiumException $ex) {
-                        throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
-                    }
+        }
+
+        $encodedString = rtrim($encodedString, '=');
+        $srcLen = strlen($encodedString);
+
+        if (extension_loaded('sodium')) {
+            $variant = match(static::class) {
+                Base64::class => SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING,
+                Base64UrlSafe::class => SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING,
+                default => 0,
+            };
+            if ($variant > 0) {
+                try {
+                    return sodium_base642bin($encodedString, $variant);
+                } catch (SodiumException $ex) {
+                    throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
                 }
             }
-        } else {
-            $encodedString = rtrim($encodedString, '=');
-            $srcLen = strlen($encodedString);
         }
 
         $err = 0;

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -221,7 +221,7 @@ abstract class Base64 implements EncoderInterface
                 };
                 if ($variant > 0) {
                     try {
-                        return sodium_base642bin($encodedString, $variant);
+                        return sodium_base642bin(\rtrim($encodedString, '='), $variant);
                     } catch (SodiumException $ex) {
                         throw new RangeException($ex->getMessage(), $ex->getCode(), $ex);
                     }


### PR DESCRIPTION
Hi,

Latest update introduced an issue with `Base64::decode` function with `strictPadding` enabled. When `strictPadding` is true, than the string is analyzed to contain correct amount of padding before passing the string to sodium function.

BUT sodium decode mode is set to NO_PADDING, but we fail to remove it beforehand, which causes an issue.

Due to the fact that we need to remove the padding in both bases, I also introduced a small refactoring, which enables sodium implementation to be used even when `strictPadding` is set to false.

Feel free to modify the code according to your QA rules.

Best regards,

Václav Pelíšek